### PR TITLE
Aliases for units and functionals

### DIFF
--- a/lib/tconsole.rb
+++ b/lib/tconsole.rb
@@ -92,7 +92,6 @@ module TConsole
       while line = Readline.readline("tconsole> ", true)
         line.strip!
         args = line.split(/\s/)
-
         if line == ""
           # do nothing
         elsif args[0] == "exit"
@@ -111,10 +110,10 @@ module TConsole
           server.run_recent(args[1])
         elsif args[0] == "uncommitted"
           server.run_uncommitted(args[1])
-        elsif args[0] == "all"
-          server.run_tests(["test/unit/**/*_test.rb", "test/functional/**/*_test.rb", "test/integration/**/*_test.rb"], args[1])
         elsif args[0] == "failed"
           server.run_failed(args[1])
+        elsif args[0] == "all"
+          server.run_tests(["test/unit/**/*_test.rb", "test/functional/**/*_test.rb", "test/integration/**/*_test.rb"], args[1])
         elsif args[0] == "info"
           server.run_info
         else
@@ -136,6 +135,7 @@ module TConsole
       puts "integration [test_pattern]  # Run integration tests"
       puts "recent [test_pattern]       # Run tests for recently changed files"
       puts "uncommitted [test_pattern]  # Run tests for uncommitted changes"
+      puts "failed                      # Run the last failed tests"
       puts "[filename] [test_pattern]   # Run the tests contained in the given file"
       puts "reload                      # Reload your Rails environment"
       puts "exit                        # Exit the console"

--- a/lib/tconsole.rb
+++ b/lib/tconsole.rb
@@ -113,6 +113,8 @@ module TConsole
           server.run_uncommitted(args[1])
         elsif args[0] == "all"
           server.run_tests(["test/unit/**/*_test.rb", "test/functional/**/*_test.rb", "test/integration/**/*_test.rb"], args[1])
+        elsif args[0] == "failed"
+          server.run_failed(args[1])
         elsif args[0] == "info"
           server.run_info
         else

--- a/lib/tconsole/minitest_handler.rb
+++ b/lib/tconsole/minitest_handler.rb
@@ -8,7 +8,7 @@ module TConsole
 
       runner = MiniTest::Unit.runner
       runner.run(args)
-      Server.last_failed = runner.report.map {|item| item.match(/\((\w+)\)/)[1] } if runner.failures > 0
+      server.last_failed = runner.report.map {|item| item.match(/\((\w+)\)/)[1] } if runner.failures > 0
 
       patch_minitest
     end

--- a/lib/tconsole/minitest_handler.rb
+++ b/lib/tconsole/minitest_handler.rb
@@ -6,7 +6,9 @@ module TConsole
         args = ["--name", name_pattern]
       end
 
-      MiniTest::Unit.runner.run(args)
+      runner = MiniTest::Unit.runner
+      runner.run(args)
+      Server.last_failed = runner.report.map {|item| item.match(/\((\w+)\)/)[1] } if runner.failures > 0
 
       patch_minitest
     end

--- a/lib/tconsole/server.rb
+++ b/lib/tconsole/server.rb
@@ -1,9 +1,10 @@
 module TConsole
   class Server
-    attr_accessor :config
+    attr_accessor :config, :last_failed
 
     def initialize(config)
       self.config = config
+      self.last_failed = []
     end
 
     def stop
@@ -90,6 +91,14 @@ module TConsole
 
       message = "Running #{files.length} #{files.length == 1 ? "test file" : "test files"} based on changed files..."
       run_tests(files, test_pattern, message)
+    end
+
+    def run_failed(test_pattern)
+      file_names = self.last_failed.map {|class_name| class_name.tableize.singularize}
+      files_to_rerun = []
+      files_to_rerun << file_name.map {|file| (file.match(/controller/)) ? "/functionals/#{file}.rb" : "/units/#{file}.rb"}
+      message = "Running last failed tests"
+      run_tests(files_to_rerun, test_pattern, message)
     end
 
     def recent_files(touched_since, source_pattern, test_path)

--- a/lib/tconsole/server.rb
+++ b/lib/tconsole/server.rb
@@ -23,7 +23,9 @@ module TConsole
           require 'rake'
           Rake.application.init
           Rake.application.load_rakefile
-          Rake.application.invoke_task("db:test:load")
+          if Rake.application.tasks.include?("db:test:load")
+            Rake.application.invoke_task("db:test:load")
+          end
           Rake.application.invoke_task("test:prepare")
         rescue Exception => e
           puts "Error - Loading your environment failed: #{e.message}"


### PR DESCRIPTION
Now, a user can type unit or units, as well as functional or functionals.
