### PR TITLE
Fix 'MySQL server has gone away'. 

### DIFF
--- a/lib/tconsole/server.rb
+++ b/lib/tconsole/server.rb
@@ -53,12 +53,12 @@ module TConsole
             paths.concat(Dir.glob(glob))
           end
 
-          paths.each do |path|
-            require File.realpath(path)
-          end
-
           if defined? ActiveRecord
             ActiveRecord::Base.connection.reconnect!
+          end
+
+          paths.each do |path|
+            require File.realpath(path)
           end
 
           if defined?(MiniTest)


### PR DESCRIPTION
Reconnect to ActiveRecord before requiring test files so the database is available when, for example, scopes are being constructed in the test files.
