### PR TITLE
a few tweaks to get this running on 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 
 gem "rake"
 gem "nutrasuite"
+
+platforms :mri_18 do
+  gem "minitest"
+end

--- a/lib/tconsole.rb
+++ b/lib/tconsole.rb
@@ -13,6 +13,12 @@ require "drb/drb"
 require "term/ansicolor"
 require "shellwords"
 
+if RUBY_VERSION =~ /1.8/
+  def Kernel.one_eight?; true; end
+  def Dir.home; File.expand_path('~'); end
+  def Dir.exists?(path); File.exists?(path) and File.directory?(path); end
+end
+
 module TConsole
   class Runner
 

--- a/lib/tconsole/console.rb
+++ b/lib/tconsole/console.rb
@@ -74,7 +74,7 @@ module TConsole
       args = Shellwords.shellwords(command)
 
       # save the command unless we're exiting or repeating the last command
-      unless args[0] == "exit" || (Readline::HISTORY.length > 0 && Readline::HISTORY[Readline::HISTORY.length - 1] == command)
+      unless args[0] == "exit" || last_command == command
         Readline::HISTORY << command
       end
 
@@ -156,6 +156,15 @@ module TConsole
 
     def history_file
       File.join(ENV['HOME'], ".tconsole_history")
+    end
+
+    def last_command
+      return nil if Readline::HISTORY.length <= 0
+      if Kernel.one_eight?
+        Readline::HISTORY.to_a[Readline::HISTORY.length - 1]
+      else
+        Readline::HISTORY[Readline::HISTORY.length - 1]
+      end
     end
 
     # Stores last 50 items in history to $HOME/.tconsole_history

--- a/lib/tconsole/server.rb
+++ b/lib/tconsole/server.rb
@@ -11,8 +11,13 @@ module TConsole
     def handle(message)
       action = message[:action]
       args = message[:args]
-
-      send(action, *args)
+      if Kernel.one_eight?
+        self.class.instance_method(action).arity > 0 ?
+          send(action, *args) :
+          send(action)
+      else
+        send(action, *args)
+      end
     end
 
     def stop

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require "rubygems"
 require "bundler/setup"
 
 require 'test/unit'
+require 'minitest/autorun' if RUBY_VERSION =~ /1.8/
 require 'nutrasuite'
 
 require 'tconsole'


### PR DESCRIPTION
I know 1.9 is the preferred Ruby version, but for us schmucks that are stuck in 1.8 land (MRI/ree/etc.) these tweaks should allow us to run tconsole too.
