### PR TITLE
Only patch MiniTest once

### DIFF
--- a/lib/tconsole/minitest_handler.rb
+++ b/lib/tconsole/minitest_handler.rb
@@ -25,8 +25,6 @@ module TConsole
       end
 
       results
-
-      patch_minitest
     end
 
 


### PR DESCRIPTION
`patch_minitest` is called twice in `TConsole::MiniTestHandler.preload_elements`.  Removing the second call has the side effect of resolving gma/tconsole#75
