### PR TITLE
Rename all "Term" to less used "Termin"

### DIFF
--- a/lib/tconsole.rb
+++ b/lib/tconsole.rb
@@ -4,7 +4,7 @@ require "chattyproc"
 require "optparse"
 require "readline"
 require "benchmark"
-require "term/ansicolor"
+require "termin/ansicolor"
 require "shellwords"
 
 require "tconsole/config"

--- a/lib/tconsole/minitest_handler.rb
+++ b/lib/tconsole/minitest_handler.rb
@@ -47,10 +47,10 @@ module TConsole
   # Custom minitest runner for tconsole
   class MiniTestUnit < ::MiniTest::Unit
     COLOR_MAP = {
-      "S" => ::Term::ANSIColor.cyan,
-      "E" => ::Term::ANSIColor.red,
-      "F" => ::Term::ANSIColor.red,
-      "P" => ::Term::ANSIColor.green
+      "S" => ::Termin::ANSIColor.cyan,
+      "E" => ::Termin::ANSIColor.red,
+      "F" => ::Termin::ANSIColor.red,
+      "P" => ::Termin::ANSIColor.green
     }
 
     attr_accessor :match_patterns, :config, :results, :passes, :interrupted
@@ -110,28 +110,28 @@ module TConsole
 
       if test_count == 0
         if !match_patterns.empty?
-          puts ::Term::ANSIColor.yellow("No tests were executed because no tests matching `#{match_patterns.join(", ")}` were found.")
+          puts ::Termin::ANSIColor.yellow("No tests were executed because no tests matching `#{match_patterns.join(", ")}` were found.")
         else
-          puts ::Term::ANSIColor.yellow("No tests were executed.")
+          puts ::Termin::ANSIColor.yellow("No tests were executed.")
         end
       else
         format = "%d tests, %d assertions, "
 
         format << COLOR_MAP["P"] if passes > 0
         format << "%d passes, "
-        format << ::Term::ANSIColor.reset if passes > 0
+        format << ::Termin::ANSIColor.reset if passes > 0
 
         format << COLOR_MAP["F"] if failures > 0
         format << "%d failures, "
-        format << ::Term::ANSIColor.reset if failures > 0
+        format << ::Termin::ANSIColor.reset if failures > 0
 
         format << COLOR_MAP["E"] if errors > 0
         format << "%d errors, "
-        format << ::Term::ANSIColor.reset if errors > 0
+        format << ::Termin::ANSIColor.reset if errors > 0
 
         format << COLOR_MAP["S"] if skips > 0
         format << "%d skips"
-        format << ::Term::ANSIColor.reset if skips > 0
+        format << ::Termin::ANSIColor.reset if skips > 0
 
         io.puts format % [test_count, assertion_count, passes, failures, errors, skips]
       end
@@ -168,8 +168,8 @@ module TConsole
 
           # Print the suite name if needed
           unless @last_suite == suite
-            print("\n\n", ::Term::ANSIColor.cyan, suite, ::Term::ANSIColor.reset,
-                  ::Term::ANSIColor.magenta, " #{suite_id}", ::Term::ANSIColor.reset, "\n")
+            print("\n\n", ::Termin::ANSIColor.cyan, suite, ::Termin::ANSIColor.reset,
+                  ::Termin::ANSIColor.magenta, " #{suite_id}", ::Termin::ANSIColor.reset, "\n")
             @last_suite = suite
           end
 
@@ -191,11 +191,11 @@ module TConsole
 
           output = "#{result} #{method}"
 
-          print COLOR_MAP[result], " #{output}", ::Term::ANSIColor.reset, " #{"%0.6f" % time }s ",
-            ::Term::ANSIColor.magenta, "#{id}", ::Term::ANSIColor.reset, "\n"
+          print COLOR_MAP[result], " #{output}", ::Termin::ANSIColor.reset, " #{"%0.6f" % time }s ",
+            ::Termin::ANSIColor.magenta, "#{id}", ::Termin::ANSIColor.reset, "\n"
 
           if @failed_fast
-            print "\n", COLOR_MAP["E"], "Halting tests because of failure.", ::Term::ANSIColor.reset, "\n"
+            print "\n", COLOR_MAP["E"], "Halting tests because of failure.", ::Termin::ANSIColor.reset, "\n"
           end
 
           inst._assertions
@@ -212,11 +212,11 @@ module TConsole
           when MiniTest::Skip then
             @skips += 1
             results.skip_count += 1
-            ["S", COLOR_MAP["S"] + "Skipped:\n#{klass}##{meth} (#{id})" + ::Term::ANSIColor.reset + " [#{location e}]:\n#{e.message}\n"]
+            ["S", COLOR_MAP["S"] + "Skipped:\n#{klass}##{meth} (#{id})" + ::Termin::ANSIColor.reset + " [#{location e}]:\n#{e.message}\n"]
           when MiniTest::Assertion then
             @failures += 1
             results.failure_count += 1
-            ["F", COLOR_MAP["F"] + "Failure:\n#{klass}##{meth} (#{id})" + ::Term::ANSIColor.reset + " [#{location e}]:\n#{e.message}\n"]
+            ["F", COLOR_MAP["F"] + "Failure:\n#{klass}##{meth} (#{id})" + ::Termin::ANSIColor.reset + " [#{location e}]:\n#{e.message}\n"]
           else
             @errors += 1
             results.error_count += 1
@@ -224,7 +224,7 @@ module TConsole
             filtered_backtrace = Util.filter_backtrace(e.backtrace)
             backtrace_text = MiniTest::filter_backtrace(filtered_backtrace).join "\n    "
 
-            ["E", COLOR_MAP["E"] + "Error:\n#{klass}##{meth} (#{id}):\n" + ::Term::ANSIColor.reset + "#{e.class}: #{e.message}\n    #{backtrace_text}\n"]
+            ["E", COLOR_MAP["E"] + "Error:\n#{klass}##{meth} (#{id}):\n" + ::Termin::ANSIColor.reset + "#{e.class}: #{e.message}\n    #{backtrace_text}\n"]
           end
       @report << e[1]
       e[0]
@@ -233,4 +233,4 @@ module TConsole
 end
 
 # Make sure that output is only colored when it should be
-Term::ANSIColor::coloring = STDOUT.isatty
+Termin::ANSIColor::coloring = STDOUT.isatty

--- a/lib/tconsole/reporter.rb
+++ b/lib/tconsole/reporter.rb
@@ -15,17 +15,17 @@ module TConsole
     # Public: Outputs a positive informative message.
     # Colors it green if the console supports it.
     def exclaim(message = "")
-      puts ::Term::ANSIColor.green(message)
+      puts ::Termin::ANSIColor.green(message)
     end
 
     # Public: Outputs a warning message.
     def warn(message = "")
-      puts ::Term::ANSIColor.yellow(message)
+      puts ::Termin::ANSIColor.yellow(message)
     end
 
     # Public: Outputs an error message.
     def error(message = "")
-      puts ::Term::ANSIColor.red(message)
+      puts ::Termin::ANSIColor.red(message)
     end
 
 
@@ -46,12 +46,12 @@ module TConsole
     def timing(timing, test_id)
       output = "#{"%0.6f" % timing[:time]}s #{timing[:name]}"
       if timing[:time] > 1
-        print ::Term::ANSIColor.red, output, ::Term::ANSIColor.reset
+        print ::Termin::ANSIColor.red, output, ::Termin::ANSIColor.reset
       else
-        print ::Term::ANSIColor.green, output, ::Term::ANSIColor.reset
+        print ::Termin::ANSIColor.green, output, ::Termin::ANSIColor.reset
       end
 
-      print ::Term::ANSIColor.magenta, " #{last_result}", ::Term::ANSIColor.reset, "\n"
+      print ::Termin::ANSIColor.magenta, " #{last_result}", ::Termin::ANSIColor.reset, "\n"
     end
 
     # Public: Prints a list of available commands

--- a/lib/tconsole/version.rb
+++ b/lib/tconsole/version.rb
@@ -1,3 +1,3 @@
 module TConsole
-  VERSION = "1.3.0.pre2"
+  VERSION = "1.3.0.pre3"
 end

--- a/tconsole.gemspec
+++ b/tconsole.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
   s.add_runtime_dependency "chattyproc", "~> 1.0.0"
-  s.add_runtime_dependency "term-ansicolor", "~> 1.0.7"
+  s.add_runtime_dependency "termin-ansicolor", "~> 1.3.0.2"
 end


### PR DESCRIPTION
The name _Term_ is often use like as model name in projects. 

I've send pull request to gem "term-ansicolor" https://github.com/flori/term-ansicolor/pull/23, but it's not merged yet. I've create my own gem "termin-ansicolor" and pushed it Rubygems. It differs from _term-ansicolor_ main module name only (see changed files at pull request). So just my pull request in term-ansicolor is merged, I'll change dependency gem in tconsole from _termin-ansicolor_ to *term-ansicolor".

I've decided to change module name from Term to Termin, because the second word is less used (see search results on Github Ruby, for example).
